### PR TITLE
Support for storing and updating bucket ACLs.

### DIFF
--- a/include/stanchion.hrl
+++ b/include/stanchion.hrl
@@ -9,10 +9,28 @@
           key_id :: string(),
           key_secret :: string(),
           canonical_id :: string(),
-          buckets=[] :: [term()]}).
+          buckets=[] :: [moss_bucket()]}).
 -type moss_user() :: #moss_user_v1{}.
 
+-record(moss_bucket_v1, {
+          name :: string(),
+          last_action :: created | deleted,
+          creation_date :: string(),
+          modification_time :: erlang:timestamp(),
+          acl :: acl_v1()}).
+-type moss_bucket() :: #moss_bucket_v1{}.
+
+-type acl_perm() :: 'READ' | 'WRITE' | 'READ_ACP' | 'WRITE_ACP' | 'FULL_CONTROL'.
+-type acl_perms() :: [acl_perm()].
+-type acl_grant() :: {{string(), string()}, acl_perms()}.
+-record(acl_v1, {owner={"", ""} :: {string(), string()},
+                 grants=[] :: [acl_grant()],
+                 creation_time=now() :: erlang:timestamp()}).
+-type acl_v1() :: #acl_v1{}.
+
+-define(ACL, #acl_v1).
 -define(USER_BUCKET, <<"moss.users">>).
 -define(BUCKETS_BUCKET, <<"moss.buckets">>).
 -define(FREE_BUCKET_MARKER, <<"0">>).
 -define(MOSS_USER, #moss_user_v1).
+-define(MD_ACL, <<"X-Moss-Acl">>).

--- a/src/stanchion_acl_utils.erl
+++ b/src/stanchion_acl_utils.erl
@@ -1,0 +1,374 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc ACL utility functions
+
+-module(stanchion_acl_utils).
+
+-include("stanchion.hrl").
+-include_lib("xmerl/include/xmerl.hrl").
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-endif.
+
+%% Public API
+-export([acl/4,
+         acl_from_json/1,
+         acl_to_json_term/1
+        ]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Construct an acl. The structure is the same for buckets
+%% and objects.
+-spec acl(string(), string(), [acl_grant()], erlang:timestamp()) -> acl_v1().
+acl(DisplayName, CanonicalId, Grants, CreationTime) ->
+    OwnerData = {DisplayName, CanonicalId},
+    ?ACL{owner=OwnerData,
+         grants=Grants,
+         creation_time=CreationTime}.
+
+%% @doc Convert a set of JSON terms representing an ACL into
+%% an internal representation.
+-spec acl_from_json(term()) -> acl_v1().
+acl_from_json({struct, Json}) ->
+    process_acl_contents(Json, ?ACL{});
+acl_from_json(Json) ->
+    process_acl_contents(Json, ?ACL{}).
+
+%% @doc Convert an internal representation of an ACL into
+%% erlang terms that can be encoded using `mochijson2:encode'.
+-spec acl_to_json_term(acl_v1()) -> term().
+acl_to_json_term(#acl_v1{owner={DisplayName, CanonicalId},
+                         grants=Grants,
+                         creation_time=CreationTime}) ->
+    {struct, [{<<"acl">>,
+               {struct, [{<<"version">>, 1},
+                         owner_to_json_term(DisplayName, CanonicalId),
+                         grants_to_json_term(Grants, []),
+                         erlang_time_to_json_term(CreationTime)]}
+              }]}.
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+%% @doc Convert an information from an ACL into erlang
+%% terms that can be encoded using `mochijson2:encode'.
+-spec erlang_time_to_json_term(erlang:timestamp()) -> term().
+erlang_time_to_json_term({MegaSecs, Secs, MicroSecs}) ->
+    {<<"creation_time">>,
+     {struct, [{<<"mega_seconds">>, MegaSecs},
+               {<<"seconds">>, Secs},
+               {<<"micro_seconds">>, MicroSecs}]}
+    }.
+
+%% @doc Convert grantee information from an ACL into erlang
+%% terms that can be encoded using `mochijson2:encode'.
+-spec grantee_to_json_term(acl_grant()) -> term().
+grantee_to_json_term({Group, Perms}) when is_atom(Group) ->
+    {struct, [{<<"group">>, list_to_binary(
+                              atom_to_list(Group))},
+              {<<"permissions">>, permissions_to_json_term(Perms)}]};
+grantee_to_json_term({{DisplayName, CanonicalId}, Perms}) ->
+    {struct, [{<<"display_name">>, list_to_binary(DisplayName)},
+              {<<"canonical_id">>, list_to_binary(CanonicalId)},
+              {<<"permissions">>, permissions_to_json_term(Perms)}]}.
+
+%% @doc Convert owner information from an ACL into erlang
+%% terms that can be encoded using `mochijson2:encode'.
+-spec grants_to_json_term([acl_grant()], [term()]) -> term().
+grants_to_json_term([], GrantTerms) ->
+    {<<"grants">>, GrantTerms};
+grants_to_json_term([HeadGrant | RestGrants], GrantTerms) ->
+    grants_to_json_term(RestGrants,
+                        [grantee_to_json_term(HeadGrant) | GrantTerms]).
+
+%% @doc Convert owner information from an ACL into erlang
+%% terms that can be encoded using `mochijson2:encode'.
+-spec owner_to_json_term(string(), string()) -> term().
+owner_to_json_term(DisplayName, CanonicalId) ->
+    {<<"owner">>,
+     {struct, [{<<"display_name">>, list_to_binary(DisplayName)},
+               {<<"canonical_id">>, list_to_binary(CanonicalId)}]}
+    }.
+
+%% @doc Convert a list of permissions into binaries
+%% that can be encoded using `mochijson2:encode'.
+-spec permissions_to_json_term(acl_perms()) -> term().
+permissions_to_json_term(Perms) ->
+    [list_to_binary(atom_to_list(Perm)) || Perm <- Perms].
+
+%% @doc Process the top-level elements of the
+-spec process_acl_contents([term()], acl_v1()) -> acl_v1().
+process_acl_contents([], Acl) ->
+    Acl;
+process_acl_contents([{Name, Value} | RestObjects], Acl) ->
+    lager:debug("Object name: ~p", [Name]),
+    case Name of
+        <<"owner">> ->
+            {struct, OwnerData} = Value,
+            UpdAcl = process_owner(OwnerData, Acl);
+        <<"grants">> ->
+            UpdAcl = process_grants(Value, Acl);
+        <<"creation_time">> ->
+            {struct, TimeData} = Value,
+            CreationTime = process_creation_time(TimeData, {1,1,1}),
+            UpdAcl = Acl?ACL{creation_time=CreationTime};
+        _ ->
+            UpdAcl = Acl
+    end,
+    process_acl_contents(RestObjects, UpdAcl).
+
+%% @doc Process an JSON element containing acl owner information.
+-spec process_owner([term()], acl_v1()) -> acl_v1().
+process_owner([], Acl) ->
+    Acl;
+process_owner([{Name, Value} | RestObjects], Acl) ->
+    Owner = Acl?ACL.owner,
+    case Name of
+        <<"canonical_id">> ->
+            lager:debug("Owner ID value: ~p", [Value]),
+            {OwnerName, _} = Owner,
+            UpdOwner = {OwnerName, binary_to_list(Value)};
+        <<"display_name">> ->
+            lager:debug("Owner Name content: ~p", [Value]),
+            {_, OwnerId} = Owner,
+            UpdOwner = {binary_to_list(Value), OwnerId};
+        _ ->
+            lager:debug("Encountered unexpected element: ~p", [Name]),
+            UpdOwner = Owner
+    end,
+    process_owner(RestObjects, Acl?ACL{owner=UpdOwner}).
+
+%% @doc Process an JSON element containing the grants for the acl.
+-spec process_grants([term()], acl_v1()) -> acl_v1().
+process_grants([], Acl) ->
+    Acl;
+process_grants([{_, Value} | RestObjects], Acl) ->
+    Grant = process_grant(Value, {{"", ""}, []}),
+    UpdAcl = Acl?ACL{grants=[Grant | Acl?ACL.grants]},
+    process_grants(RestObjects, UpdAcl).
+
+%% @doc Process an JSON element containing information about
+%% an ACL permission grants.
+-spec process_grant([term()], acl_grant()) -> acl_grant().
+process_grant([], Grant) ->
+    Grant;
+process_grant([{Name, Value} | RestObjects], Grant) ->
+    case Name of
+        <<"canonical_id">> ->
+            lager:debug("ID value: ~p", [Value]),
+            {{DispName, _}, Perms} = Grant,
+            UpdGrant = {{DispName, binary_to_list(Value)}, Perms};
+        <<"display_name">> ->
+            lager:debug("Name value: ~p", [Value]),
+            {{_, Id}, Perms} = Grant,
+            UpdGrant = {{binary_to_list(Value), Id}, Perms};
+        <<"group">> ->
+            lager:debug("Group value: ~p", [Value]),
+            {_, Perms} = Grant,
+            UpdGrant = {list_to_atom(
+                          binary_to_list(Value)), Perms};
+        <<"permissions">> ->
+            {Grantee, _} = Grant,
+            Perms = process_permissions(Value),
+            lager:debug("Perms value: ~p", [Value]),
+            UpdGrant = {Grantee, Perms};
+        _ ->
+            UpdGrant = Grant
+    end,
+    process_grant(RestObjects, UpdGrant).
+
+%% @doc Process a list of JSON elements containing
+%% ACL permissions.
+-spec process_permissions([binary()]) -> acl_perms().
+process_permissions(Perms) ->
+    lists:usort(
+      lists:filter(fun(X) -> X /= undefined end,
+                   [binary_perm_to_atom(Perm) || Perm <- Perms])).
+
+%% @doc Convert a binary permission type to a
+%% corresponding atom or return `undefined' if
+%% the permission is invalid.
+-spec binary_perm_to_atom(binary()) -> atom().
+binary_perm_to_atom(Perm) ->
+    case Perm of
+        <<"FULL_CONTROL">> ->
+            'FULL_CONTROL';
+        <<"READ">> ->
+            'READ';
+        <<"READ_ACP">> ->
+            'READ_ACP';
+        <<"WRITE">> ->
+            'WRITE';
+        <<"WRITE_ACP">> ->
+            'WRITE_ACP';
+        _ ->
+            undefined
+    end.
+
+%% @doc Process the JSON element containing creation time
+%% data for an ACL.
+-spec process_creation_time([term()], erlang:timestamp()) -> erlang:timestamp().
+process_creation_time([], CreationTime) ->
+    CreationTime;
+process_creation_time([{Name, Value} | RestObjects], CreationTime) ->
+    case Name of
+        <<"mega_seconds">> ->
+            {_, Secs, MicroSecs} = CreationTime,
+            UpdCreationTime = {Value, Secs, MicroSecs};
+        <<"seconds">> ->
+            {MegaSecs, _, MicroSecs} = CreationTime,
+            UpdCreationTime = {MegaSecs, Value, MicroSecs};
+        <<"micro_seconds">> ->
+            {MegaSecs, Secs, _} = CreationTime,
+            UpdCreationTime = {MegaSecs, Secs, Value}
+    end,
+    process_creation_time(RestObjects, UpdCreationTime).
+
+%% ===================================================================
+%% Eunit tests
+%% ===================================================================
+
+-ifdef(TEST).
+
+acl_from_json_test() ->
+    CreationTime = erlang:now(),
+    {AclMegaSecs, AclSecs, AclMicroSecs} = CreationTime,
+    JsonTerm = [{<<"version">>,1},
+                {<<"owner">>,
+                 {struct,
+                  [{<<"display_name">>,<<"tester1">>},
+                   {<<"canonical_id">>,<<"TESTID1">>}]}},
+                {<<"grants">>,
+                 [{struct,
+                   [{<<"group">>,<<"AllUsers">>},
+                    {<<"permissions">>,[<<"WRITE_ACP">>]}]},
+                  {struct,
+                   [{<<"display_name">>,<<"tester2">>},
+                    {<<"canonical_id">>,<<"TESTID2">>},
+                    {<<"permissions">>,[<<"WRITE">>]}]},
+                  {struct,
+                   [{<<"display_name">>,<<"tester1">>},
+                    {<<"canonical_id">>,<<"TESTID1">>},
+                    {<<"permissions">>,[<<"READ">>]}]}]},
+                {<<"creation_time">>,
+                 {struct,
+                  [{<<"mega_seconds">>, AclMegaSecs},
+                   {<<"seconds">>, AclSecs},
+                   {<<"micro_seconds">>, AclMicroSecs}]}}],
+    Acl = acl_from_json(JsonTerm),
+    ExpectedAcl = acl("tester1",
+                      "TESTID1",
+                      [{{"tester1", "TESTID1"}, ['READ']},
+                       {{"tester2", "TESTID2"}, ['WRITE']},
+                       {'AllUsers', ['WRITE_ACP']}],
+                      CreationTime),
+    ?assertEqual(ExpectedAcl, Acl).
+
+acl_to_json_term_test() ->
+    CreationTime = erlang:now(),
+    Acl = acl("tester1",
+              "TESTID1",
+              [{{"tester1", "TESTID1"}, ['READ']},
+               {{"tester2", "TESTID2"}, ['WRITE']}],
+              CreationTime),
+    JsonTerm = acl_to_json_term(Acl),
+    {AclMegaSecs, AclSecs, AclMicroSecs} = CreationTime,
+    ExpectedTerm = {struct,
+                    [{<<"acl">>,
+                      {struct,
+                       [{<<"version">>,1},
+                        {<<"owner">>,
+                         {struct,
+                          [{<<"display_name">>,<<"tester1">>},
+                           {<<"canonical_id">>,<<"TESTID1">>}]}},
+                        {<<"grants">>,
+                         [{struct,
+                           [{<<"display_name">>,<<"tester2">>},
+                            {<<"canonical_id">>,<<"TESTID2">>},
+                            {<<"permissions">>,[<<"WRITE">>]}]},
+                          {struct,
+                           [{<<"display_name">>,<<"tester1">>},
+                            {<<"canonical_id">>,<<"TESTID1">>},
+                            {<<"permissions">>,[<<"READ">>]}]}]},
+                        {<<"creation_time">>,
+                         {struct,
+                          [{<<"mega_seconds">>, AclMegaSecs},
+                           {<<"seconds">>, AclSecs},
+                           {<<"micro_seconds">>, AclMicroSecs}]}}]}}]},
+    ?assertEqual(ExpectedTerm, JsonTerm).
+
+owner_to_json_term_test() ->
+    JsonTerm = owner_to_json_term("name", "id123"),
+    ExpectedTerm = {<<"owner">>,
+                    {struct, [{<<"display_name">>, <<"name">>},
+                              {<<"canonical_id">>, <<"id123">>}]}
+                   },
+    ?assertEqual(ExpectedTerm, JsonTerm).
+
+grants_to_json_term_test() ->
+    CreationTime = erlang:now(),
+    Acl = acl("tester1",
+              "TESTID1",
+              [{{"tester1", "TESTID1"}, ['READ']},
+               {{"tester2", "TESTID2"}, ['WRITE']}],
+              CreationTime),
+    JsonTerm = grants_to_json_term(Acl?ACL.grants, []),
+    ExpectedTerm =
+        {<<"grants">>, [{struct,
+                         [{<<"display_name">>,<<"tester2">>},
+                          {<<"canonical_id">>,<<"TESTID2">>},
+                          {<<"permissions">>,[<<"WRITE">>]}]},
+                        {struct,
+                         [{<<"display_name">>,<<"tester1">>},
+                          {<<"canonical_id">>,<<"TESTID1">>},
+                          {<<"permissions">>,[<<"READ">>]}]}]},
+
+    ?assertEqual(ExpectedTerm, JsonTerm).
+
+grantee_to_json_term_test() ->
+    JsonTerm1 = grantee_to_json_term({{"tester1", "TESTID1"}, ['READ']}),
+    JsonTerm2 = grantee_to_json_term({'AllUsers', ['WRITE']}),
+    ExpectedTerm1 = {struct,
+                     [{<<"display_name">>,<<"tester1">>},
+                      {<<"canonical_id">>,<<"TESTID1">>},
+                      {<<"permissions">>,[<<"READ">>]}]},
+    ExpectedTerm2 = {struct,
+                     [{<<"group">>,<<"AllUsers">>},
+                      {<<"permissions">>,[<<"WRITE">>]}]},
+    ?assertEqual(ExpectedTerm1, JsonTerm1),
+    ?assertEqual(ExpectedTerm2, JsonTerm2).
+
+permissions_to_json_term_test() ->
+    JsonTerm = permissions_to_json_term(['READ',
+                                         'WRITE',
+                                         'READ_ACP',
+                                         'WRITE_ACP',
+                                         'FULL_CONTROL']),
+    ExpectedTerm = [<<"READ">>,
+                    <<"WRITE">>,
+                    <<"READ_ACP">>,
+                    <<"WRITE_ACP">>,
+                    <<"FULL_CONTROL">>],
+    ?assertEqual(ExpectedTerm, JsonTerm).
+
+erlang_time_to_json_term_test() ->
+    JsonTerm = erlang_time_to_json_term({1000, 100, 10}),
+    ExpectedTerm = {<<"creation_time">>,
+                    {struct,
+                     [{<<"mega_seconds">>, 1000},
+                      {<<"seconds">>, 100},
+                      {<<"micro_seconds">>, 10}]}},
+    ?assertEqual(ExpectedTerm, JsonTerm).
+
+-endif.

--- a/src/stanchion_web.erl
+++ b/src/stanchion_web.erl
@@ -19,6 +19,7 @@ dispatch_table() ->
     end,
     [
      {["buckets"], stanchion_wm_buckets, [{auth_bypass, AuthBypass}]},
+     {["buckets", bucket, "acl"], stanchion_wm_acl, [{auth_bypass, AuthBypass}]},
      {["buckets", bucket], stanchion_wm_bucket, [{auth_bypass, AuthBypass}]},
      {["users"], stanchion_wm_users, [{auth_bypass, AuthBypass}]}
     ].

--- a/src/stanchion_wm_acl.erl
+++ b/src/stanchion_wm_acl.erl
@@ -1,0 +1,87 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+-module(stanchion_wm_acl).
+
+-export([init/1,
+         service_available/2,
+         is_authorized/2,
+         content_types_provided/2,
+         malformed_request/2,
+         to_json/2,
+         allowed_methods/2,
+         content_types_accepted/2,
+         accept_body/2]).
+
+-include("stanchion.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+init(Config) ->
+    %% Check if authentication is disabled and
+    %% set that in the context.
+    AuthBypass = proplists:get_value(auth_bypass, Config),
+    {ok, #context{auth_bypass=AuthBypass}}.
+
+-spec service_available(term(), term()) -> {true, term(), term()}.
+service_available(RD, Ctx) ->
+    stanchion_wm_utils:service_available(RD, Ctx).
+
+-spec malformed_request(term(), term()) -> {false, term(), term()}.
+malformed_request(RD, Ctx) ->
+    {false, RD, Ctx}.
+
+%% @doc Check that the request is from the admin user
+is_authorized(RD, Ctx=#context{auth_bypass=AuthBypass}) ->
+    AuthHeader = wrq:get_req_header("authorization", RD),
+    case stanchion_wm_utils:parse_auth_header(AuthHeader, AuthBypass) of
+        {ok, AuthMod, Args} ->
+            case AuthMod:authenticate(RD, Args) of
+                ok ->
+                    %% Authentication succeeded
+                    {true, RD, Ctx};
+                {error, _Reason} ->
+                    %% Authentication failed, deny access
+                    stanchion_response:api_error(access_denied, RD, Ctx)
+            end
+    end.
+
+%% @doc Get the list of methods this resource supports.
+-spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
+allowed_methods(RD, Ctx) ->
+    {['GET', 'PUT'], RD, Ctx}.
+
+-spec content_types_provided(term(), term()) ->
+                                    {[{string(), atom()}], term(), term()}.
+content_types_provided(RD, Ctx) ->
+    {[{"application/json", to_xml}], RD, Ctx}.
+
+-spec content_types_accepted(term(), term()) ->
+                                    {[{string(), atom()}], term(), term()}.
+content_types_accepted(RD, Ctx) ->
+    {[{"application/json", accept_body}], RD, Ctx}.
+
+-spec to_json(term(), term()) ->
+                     {iolist(), term(), term()}.
+to_json(RD, Ctx) ->
+    Bucket = wrq:path_info(bucket, RD),
+    stanchion_response:list_bucket_response(Bucket,
+                                            RD,
+                                            Ctx).
+
+%% @doc Process the request body on `PUT'.
+accept_body(RD, Ctx) ->
+    Bucket = list_to_binary(wrq:path_info(bucket, RD)),
+    Body = wrq:req_body(RD),
+    %% @TODO Handle json decoding exceptions
+    ParsedBody = mochijson2:decode(Body),
+    FieldList = stanchion_wm_utils:json_to_proplist(ParsedBody),
+    case stanchion_utils:set_bucket_acl(Bucket,
+                                        FieldList) of
+        ok ->
+            {true, RD, Ctx};
+        {error, Reason} ->
+            stanchion_response:api_error(Reason, RD, Ctx)
+    end.


### PR DESCRIPTION
- Url encode requester key id strings and remove some debug output.
- Convert binary values from user JSON document to lists prior to storing in riak.
- Add bucket field back to user record.
- Add acl utility module to stanchion.
- Store bucket ACL when bucket is written.
- Make acl meta header name a binary and also a macro.
- Add webmachine resource and supporting functions to handle updating a bucket ACL.
- Add set_bucket_acl function to velvet module.
