### PR TITLE
Change runner script path from bin to sbin so stanchion start will work.

### DIFF
--- a/rel/vars.config
+++ b/rel/vars.config
@@ -29,7 +29,7 @@
 %% bin/stanchion
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/bin"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
 {runner_bin_dir,     "{{target_dir}}"}.
 {runner_run_dir,     "{{target_dir}}"}.
 {runner_etc_dir,     "{{target_dir}}/etc"}.


### PR DESCRIPTION
The runner script was looking in `bin` instead of `sbin` for the `stanchion` script so stanchion would not start.
