### PR TITLE
Specify default admin credentials that can be used to bootstrap a real admin user

### DIFF
--- a/rel/vars.config
+++ b/rel/vars.config
@@ -11,13 +11,15 @@
 %%
 %% etc/app.config
 %%
-{stanchion_ip,             "127.0.0.1"}.
-{stanchion_port,           8085}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
 {riak_ip,           "127.0.0.1"}.
 {riak_pb_port,      8087}.
 {moss_ip,           "127.0.0.1"}.
 {moss_port,         8080}.
 {auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
 
 %%
 %% etc/vm.args


### PR DESCRIPTION
- Set default admin credentials so that the process of bootstrapping
  an admin user is less of a hassle and so that `riak_cs` and `stanchion`
  will work together with their respective default configurations.
