### PR TITLE
Changes to support bucket deletion when there are no active files remaining for a bucket.

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -1,0 +1,171 @@
+-record(moss_user, {
+          name :: string(),
+          key_id :: string(),
+          key_secret :: string(),
+          buckets = []}).
+
+-record(moss_user_v1, {
+          name :: string(),
+          display_name :: string(),
+          email :: string(),
+          key_id :: string(),
+          key_secret :: string(),
+          canonical_id :: string(),
+          buckets=[] :: [moss_bucket()]}).
+-type moss_user() :: #moss_user_v1{}.
+
+-record(moss_bucket, {
+          name :: string(),
+          creation_date :: term(),
+          acl :: acl_v1()}).
+
+-record(moss_bucket_v1, {
+          name :: string(),
+          last_action :: created | deleted,
+          creation_date :: string(),
+          modification_time :: erlang:timestamp(),
+          acl :: acl_v1()}).
+-type moss_bucket() :: #moss_bucket_v1{}.
+-type bucket_operation() :: create | delete | update_acl.
+-type bucket_action() :: created | deleted.
+
+-record(context, {auth_bypass :: atom(),
+                  user :: moss_user(),
+                  user_vclock :: term(),
+                  bucket :: binary(),
+                  requested_perm :: acl_perm()
+                 }).
+
+-record(key_context, {context :: #context{},
+                      doc_metadata :: term(),
+                      get_fsm_pid :: pid(),
+                      putctype :: string(),
+                      bucket :: binary(),
+                      key :: list(),
+                      size :: non_neg_integer()}).
+
+-type acl_perm() :: 'READ' | 'WRITE' | 'READ_ACP' | 'WRITE_ACP' | 'FULL_CONTROL'.
+-type acl_perms() :: [acl_perm()].
+-type group_grant() :: 'AllUsers' | 'AuthUsers'.
+-type acl_grantee() :: {string(), string()} | group_grant().
+-type acl_grant() :: {acl_grantee(), acl_perms()}.
+-record(acl_v1, {owner={"", ""} :: {string(), string()},
+                 grants=[] :: [acl_grant()],
+                 creation_time=now() :: erlang:timestamp()}).
+-type acl_v1() :: #acl_v1{}.
+
+-record(lfs_manifest_v2, {
+        %% "global" properties
+        %% -----------------------------------------------------------------
+
+        %% this isn't as important anymore
+        %% since we're naming the record
+        %% to include the version number,
+        %% but I figured it's worth keeping
+        %% in case we change serialization
+        %% formats in the future.
+        version=2 :: integer(),
+
+        %% the block_size setting when this manifest
+        %% was written. Needed if the user
+        %% ever changes the block size after writing
+        %% data
+        block_size :: integer(),
+
+        %% identifying properties
+        %% -----------------------------------------------------------------
+        bkey :: {binary(), binary()},
+
+        %% user metadata that would normally
+        %% be placed on the riak_object. We avoid
+        %% putting it on the riak_object so that
+        %% we can use that metadata ourselves
+        metadata :: orddict:new(),
+
+        %% the date the manifest was created.
+        %% not sure if we need both this and
+        %% write_start_time. My thought was that
+        %% write_start_time would have millisecond
+        %% resolution, but I suppose there's no
+        %% reason we can't change created
+        %% to have millisecond as well.
+        created=riak_moss_wm_utils:iso_8601_datetime(),
+        uuid :: binary(),
+
+        %% content properties
+        %% -----------------------------------------------------------------
+        content_length :: integer(),
+        content_type :: binary(),
+        content_md5 :: term(),
+
+        %% state properties
+        %% -----------------------------------------------------------------
+        state=undefined :: undefined | writing | active | pending_delete | deleted,
+
+        %% writing/active state
+        %% -----------------------------------------------------------------
+        write_start_time :: term(), %% immutable
+
+        %% used for two purposes
+        %% 1. to mark when a file has finished uploading
+        %% 2. to decide if a write crashed before completing
+        %% and needs to be garbage collected
+        last_block_written_time :: term(),
+
+        %% a shrink-only (during resolution)
+        %% set to denote which blocks still
+        %% need to be written. We use a shrinking
+        %% (rather than growing) set to that the
+        %% set is empty after the write has completed,
+        %% which should be most of the lifespan on disk
+        write_blocks_remaining :: ordsets:new(),
+
+        %% pending_delete/deleted state
+        %% -----------------------------------------------------------------
+        %% set to the current time
+        %% when a manifest is marked as deleted
+        %% and enters the pending_delete state
+        delete_marked_time :: term(),
+
+        %% the timestamp serves a similar
+        %% purpose to last_block_written_time,
+        %% in that it's used for figuring out
+        %% when delete processes have died
+        %% and garbage collection needs to
+        %% pick up where they left off.
+        last_block_deleted_time :: term(),
+
+        %% a shrink-only (during resolution)
+        %% set to denote which blocks
+        %% still need to be deleted.
+        %% See write_blocks_remaining for
+        %% an explanation of why we chose
+        %% a shrinking set
+        delete_blocks_remaining :: ordsets:new()
+    }).
+-type lfs_manifest() :: #lfs_manifest_v2{}.
+
+-define(ACL, #acl_v1).
+-define(MOSS_BUCKET, #moss_bucket_v1).
+-define(MOSS_USER, #moss_user_v1).
+-define(USER_BUCKET, <<"moss.users">>).
+-define(BUCKETS_BUCKET, <<"moss.buckets">>).
+-define(FREE_BUCKET_MARKER, <<"0">>).
+-define(DEFAULT_MAX_CONTENT_LENGTH, 5368709120). %% 5 GB
+-define(DEFAULT_LFS_BLOCK_SIZE, 1048576).%% 1 MB
+-define(XML_PROLOG, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").
+-define(DEFAULT_STANCHION_IP, "127.0.0.1").
+-define(DEFAULT_STANCHION_PORT, 8085).
+-define(DEFAULT_STANCHION_SSL, true).
+-define(MD_ACL, "X-Moss-Acl").
+-define(EMAIL_INDEX, <<"email_bin">>).
+-define(ID_INDEX, <<"c_id_bin">>).
+-define(AUTH_USERS_GROUP, "http://acs.amazonaws.com/groups/global/AuthenticatedUsers").
+-define(ALL_USERS_GROUP, "http://acs.amazonaws.com/groups/global/AllUsers").
+-define(LOG_DELIVERY_GROUP, "http://acs.amazonaws.com/groups/s3/LogDelivery").
+-define(DEFAULT_FETCH_CONCURRENCY, 1).
+-define(DEFAULT_PUT_CONCURRENCY, 1).
+%% A number to multiplied with the block size
+%% to determine the PUT buffer size.
+%% ex. 2 would mean BlockSize * 2
+-define(DEFAULT_PUT_BUFFER_FACTOR, 1).

--- a/src/stanchion_manifest.erl
+++ b/src/stanchion_manifest.erl
@@ -1,0 +1,101 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Module for choosing and manipulating lists (well, orddict) of manifests
+
+-module(stanchion_manifest).
+
+-include("riak_moss.hrl").
+
+%% export Public API
+-export([new/2,
+         active_manifest/1,
+         mark_overwritten/1,
+         prune/1]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Return a new orddict of manifest (only
+%% one in this case). Used when storing something
+%% in Riak when the previous GET returned notfound,
+%% so we're (maybe) creating a new object.
+-spec new(binary(), lfs_manifest()) -> term().
+new(UUID, Manifest) ->
+    orddict:store(UUID, Manifest, orddict:new()).
+
+%% @doc Return the current active manifest
+%% from an orddict of manifests.
+-spec active_manifest(term()) -> {ok, lfs_manifest()} | {error, no_active_manifest}.
+active_manifest(Manifests) ->
+    case lists:foldl(fun most_recent_active_manifest/2, no_active_manifest, orddict_values(Manifests)) of
+        no_active_manifest ->
+            {error, no_active_manifest};
+        Manifest ->
+            {ok, Manifest}
+    end.
+
+%% @doc Mark all active manifests
+%% that are not "the most active"
+%% as pending_delete
+-spec mark_overwritten(term()) -> term().
+mark_overwritten(Manifests) ->
+    case active_manifest(Manifests) of
+        {error, no_active_manifest} ->
+            Manifests;
+        {ok, Active} ->
+            orddict:map(fun(_Key, Value) ->
+                    if
+                        Value == Active ->
+                            Active;
+                        Value#lfs_manifest_v2.state == active ->
+                            Value#lfs_manifest_v2{state=pending_delete,
+                                                  delete_marked_time=erlang:now()};
+                        true ->
+                            Value
+                    end end,
+                    Manifests)
+    end.
+
+
+%% @doc Return a new orddict of Manifests
+%% with any deleted and need-to-be-pruned
+%% manifests removed
+%% TODO: write the function... :)
+
+%% TODO: for pruning we're likely
+%% going to want to add some app.config
+%% stuff for how long to keep around
+%% fully deleted manifests, just like
+%% we do with vclocks.
+-spec prune(term()) -> term().
+prune(_Manifests) ->
+    ok.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+orddict_values(OrdDict) ->
+    %% orddict's are by definition
+    %% represented as lists, so no
+    %% need to call orddict:to_list,
+    %% which actually is the identity
+    %% func
+    [V || {_K, V} <- OrdDict].
+
+most_recent_active_manifest(Manifest=#lfs_manifest_v2{state=active}, no_active_manifest) ->
+    Manifest;
+most_recent_active_manifest(_Manfest, no_active_manifest) ->
+    no_active_manifest;
+most_recent_active_manifest(Man1=#lfs_manifest_v2{state=active}, Man2=#lfs_manifest_v2{state=active}) ->
+    case Man1#lfs_manifest_v2.write_start_time > Man2#lfs_manifest_v2.write_start_time of
+        true -> Man1;
+        false -> Man2
+    end;
+most_recent_active_manifest(Man1=#lfs_manifest_v2{state=active}, _Man2) -> Man1;
+most_recent_active_manifest(_Man1, Man2=#lfs_manifest_v2{state=active}) -> Man2.

--- a/src/stanchion_manifest_fsm.erl
+++ b/src/stanchion_manifest_fsm.erl
@@ -1,0 +1,390 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+-module(stanchion_manifest_fsm).
+
+-include("riak_moss.hrl").
+
+-behaviour(gen_fsm).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Test API
+-export([test_link/2]).
+
+-endif.
+
+%% API
+-export([start_link/2,
+         get_active_manifest/1,
+         add_new_manifest/2,
+         update_manifest/2,
+         mark_active_as_pending_delete/1,
+         update_manifest_with_confirmation/2,
+         stop/1]).
+
+%% gen_fsm callbacks
+-export([init/1,
+
+         %% async
+         prepare/2,
+         waiting_command/2,
+         waiting_update_command/2,
+
+         %% sync
+         waiting_command/3,
+         waiting_update_command/3,
+
+         %% rest
+         handle_event/3,
+         handle_sync_event/4,
+         handle_info/3,
+         terminate/3,
+         code_change/4]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {bucket :: binary(),
+                key :: binary(),
+                riak_object :: term(),
+
+                %% an orddict mapping
+                %% UUID -> Manifest
+                %% TODO:
+                %% maybe this can just
+                %% be pulled out of the
+                %% riak object every time?
+                manifests :: term(),
+
+                riakc_pid :: pid()
+            }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Creates a gen_fsm process which calls Module:init/1 to
+%% initialize. To ensure a synchronized start-up procedure, this
+%% function does not return until Module:init/1 has returned.
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+start_link(Bucket, Key) ->
+    gen_fsm:start_link(?MODULE, [Bucket, Key], []).
+
+get_active_manifest(Pid) ->
+    gen_fsm:sync_send_event(Pid, get_active_manifest).
+
+add_new_manifest(Pid, Manifest) ->
+    gen_fsm:send_event(Pid, {add_new_manifest, Manifest}).
+
+mark_active_as_pending_delete(Pid) ->
+    gen_fsm:sync_send_event(Pid, mark_active_as_pending_delete).
+
+update_manifest(Pid, Manifest) ->
+    gen_fsm:send_event(Pid, {update_manifest, Manifest}).
+
+update_manifest_with_confirmation(Pid, Manifest) ->
+    gen_fsm:sync_send_event(Pid, {update_manifest_with_confirmation, Manifest}).
+
+stop(Pid) ->
+    gen_fsm:sync_send_all_state_event(Pid, stop).
+
+%%%===================================================================
+%%% gen_fsm callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a gen_fsm is started using gen_fsm:start/[3,4] or
+%% gen_fsm:start_link/[3,4], this function is called by the new
+%% process to initialize.
+%%
+%% @spec init(Args) -> {ok, StateName, State} |
+%%                     {ok, StateName, State, Timeout} |
+%%                     ignore |
+%%                     {stop, StopReason}
+%% @end
+%%--------------------------------------------------------------------
+init([Bucket, Key]) ->
+    process_flag(trap_exit, true),
+    %% purposely have the timeout happen
+    %% so that we get called in the prepare
+    %% state
+    {ok, prepare, #state{bucket=Bucket, key=Key}, 0};
+init([test, Bucket, Key]) ->
+    %% skip the prepare phase
+    %% and jump right into waiting command,
+    %% creating the "mock" riakc_pb_socket
+    %% gen_server here
+    {ok, Pid} = riakc_pb_socket_fake:start_link(),
+    {ok, waiting_command, #state{bucket=Bucket, key=Key, riakc_pid=Pid}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% There should be one instance of this function for each possible
+%% state name. Whenever a gen_fsm receives an event sent using
+%% gen_fsm:send_event/2, the instance of this function with the same
+%% name as the current state name StateName is called to handle
+%% the event. It is also called if a timeout occurs.
+%%
+%% @spec state_name(Event, State) ->
+%%                   {next_state, NextStateName, NextState} |
+%%                   {next_state, NextStateName, NextState, Timeout} |
+%%                   {stop, Reason, NewState}
+%% @end
+%%--------------------------------------------------------------------
+prepare(timeout, State) ->
+    case stanchion_utils:riak_connection() of
+        {ok, RiakPid} ->
+            {next_state, waiting_command, State#state{riakc_pid=RiakPid}};
+        {error, Reason} ->
+            lager:error("Failed to establish connection to Riak. Reason: ~p",
+                        [Reason]),
+            {stop, riak_connect_failed, State}
+    end.
+
+%% This clause is for adding a new
+%% manifest that doesn't exist yet.
+%% Once it has been called _once_
+%% with a particular UUID, update_manifest
+%% should be used from then on out.
+waiting_command({add_new_manifest, Manifest}, State=#state{riakc_pid=RiakcPid,
+                                                           bucket=Bucket,
+                                                           key=Key}) ->
+    get_and_update(RiakcPid, Manifest, Bucket, Key),
+    {next_state, waiting_update_command, State}.
+
+waiting_update_command({update_manifest, Manifest}, State=#state{riakc_pid=RiakcPid,
+                                                                 bucket=Bucket,
+                                                                 key=Key,
+                                                                 riak_object=undefined,
+                                                                 manifests=undefined}) ->
+    get_and_update(RiakcPid, Manifest, Bucket, Key),
+    {next_state, waiting_update_command, State};
+waiting_update_command({update_manifest, Manifest}, State=#state{riakc_pid=RiakcPid,
+                                                                 riak_object=PreviousRiakObject,
+                                                                 manifests=PreviousManifests}) ->
+
+    WrappedManifest = stanchion_manifest:new(Manifest#lfs_manifest_v2.uuid, Manifest),
+    Resolved = stanchion_manifest_resolution:resolve([PreviousManifests, WrappedManifest]),
+    RiakObject = riakc_obj:update_value(PreviousRiakObject, term_to_binary(Resolved)),
+    %% TODO:
+    %% currently we don't do
+    %% anything to make sure
+    %% this call succeeded
+    riakc_pb_socket:put(RiakcPid, RiakObject),
+    {next_state, waiting_update_command, State#state{riak_object=undefined, manifests=undefined}}.
+
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% There should be one instance of this function for each possible
+%% state name. Whenever a gen_fsm receives an event sent using
+%% gen_fsm:sync_send_event/[2,3], the instance of this function with
+%% the same name as the current state name StateName is called to
+%% handle the event.
+%%
+%% @spec state_name(Event, From, State) ->
+%%                   {next_state, NextStateName, NextState} |
+%%                   {next_state, NextStateName, NextState, Timeout} |
+%%                   {reply, Reply, NextStateName, NextState} |
+%%                   {reply, Reply, NextStateName, NextState, Timeout} |
+%%                   {stop, Reason, NewState} |
+%%                   {stop, Reason, Reply, NewState}
+%% @end
+%%--------------------------------------------------------------------
+waiting_command(get_active_manifest, _From, State=#state{riakc_pid=RiakcPid,
+                                                         bucket=Bucket,
+                                                         key=Key}) ->
+    %% Retrieve the (resolved) value
+    %% from Riak and return the active
+    %% manifest, if there is one. Then
+    %% stash the riak_object the state
+    %% so that the next time we write
+    %% we write with the correct vector
+    %% clock.
+    case get_manifests(RiakcPid, Bucket, Key) of
+        {ok, RiakObject, Resolved} ->
+            Reply = case stanchion_manifest:active_manifest(Resolved) of
+                {ok, _Active}=ActiveReply ->
+                    ActiveReply;
+                {error, no_active_manifest} ->
+                    {error, notfound}
+            end,
+            NewState = State#state{riak_object=RiakObject, manifests=Resolved},
+            {reply, Reply, waiting_update_command, NewState};
+        {error, notfound}=NotFound ->
+            {reply, NotFound, waiting_update_command, State}
+    end;
+waiting_command(mark_active_as_pending_delete, _From, State=#state{riakc_pid=RiakcPid,
+                                                                   bucket=Bucket,
+                                                                   key=Key}) ->
+    case get_manifests(RiakcPid, Bucket, Key) of
+        {ok, RiakObject, Resolved} ->
+            Marked = orddict:map(fun(_Key, Value) ->
+                        if
+                            Value#lfs_manifest_v2.state == active ->
+                                Value#lfs_manifest_v2{state=pending_delete,
+                                                      delete_marked_time=erlang:now()};
+                            true ->
+                                Value
+                        end end, Resolved),
+            NewRiakObject = riakc_obj:update_value(RiakObject, term_to_binary(Marked)),
+            riakc_pb_socket:put(RiakcPid, NewRiakObject),
+            {stop, normal, ok, State};
+        {error, notfound}=NotFound ->
+            {stop, normal, NotFound, State}
+    end.
+
+waiting_update_command({update_manifest_with_confirmation, Manifest}, _From,
+                                            State=#state{riakc_pid=RiakcPid,
+                                            bucket=Bucket,
+                                            key=Key,
+                                            riak_object=undefined,
+                                            manifests=undefined}) ->
+    Reply = get_and_update(RiakcPid, Manifest, Bucket, Key),
+    {reply, Reply, waiting_update_command, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a gen_fsm receives an event sent using
+%% gen_fsm:send_all_state_event/2, this function is called to handle
+%% the event.
+%%
+%% @spec handle_event(Event, StateName, State) ->
+%%                   {next_state, NextStateName, NextState} |
+%%                   {next_state, NextStateName, NextState, Timeout} |
+%%                   {stop, Reason, NewState}
+%% @end
+%%--------------------------------------------------------------------
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a gen_fsm receives an event sent using
+%% gen_fsm:sync_send_all_state_event/[2,3], this function is called
+%% to handle the event.
+%%
+%% @spec handle_sync_event(Event, From, StateName, State) ->
+%%                   {next_state, NextStateName, NextState} |
+%%                   {next_state, NextStateName, NextState, Timeout} |
+%%                   {reply, Reply, NextStateName, NextState} |
+%%                   {reply, Reply, NextStateName, NextState, Timeout} |
+%%                   {stop, Reason, NewState} |
+%%                   {stop, Reason, Reply, NewState}
+%% @end
+%%--------------------------------------------------------------------
+handle_sync_event(stop, _From, _StateName, State) ->
+    Reply = ok,
+    {stop, normal, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_fsm when it receives any
+%% message other than a synchronous or asynchronous event
+%% (or a system message).
+%%
+%% @spec handle_info(Info,StateName,State)->
+%%                   {next_state, NextStateName, NextState} |
+%%                   {next_state, NextStateName, NextState, Timeout} |
+%%                   {stop, Reason, NewState}
+%% @end
+%%--------------------------------------------------------------------
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_fsm when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_fsm terminates with
+%% Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, StateName, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _StateName, #state{riakc_pid=RiakcPid}) ->
+    stanchion_utils:close_riak_connection(RiakcPid),
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, StateName, State, Extra) ->
+%%                   {ok, StateName, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% @doc
+-spec get_manifests(pid(), binary(), binary()) ->
+    {ok, term(), term()} | {error, notfound}.
+get_manifests(RiakcPid, Bucket, Key) ->
+    ManifestBucket = stanchion:to_bucket_name(objects, Bucket),
+    case riakc_pb_socket:get(RiakcPid, ManifestBucket, Key) of
+        {ok, Object} ->
+            Siblings = riakc_obj:get_values(Object),
+            DecodedSiblings = lists:map(fun erlang:binary_to_term/1, Siblings),
+            Resolved = stanchion_manifest_resolution:resolve(DecodedSiblings),
+            {ok, Object, Resolved};
+        {error, notfound}=NotFound ->
+            NotFound
+    end.
+
+get_and_update(RiakcPid, Manifest, Bucket, Key) ->
+    %% retrieve the current (resolved) value at {Bucket, Key},
+    %% add the new manifest, and then write the value
+    %% back to Riak
+    %% NOTE: it would also be nice to assert that the
+    %% UUID being added doesn't already exist in the
+    %% dict
+    WrappedManifest = stanchion_manifest:new(Manifest#lfs_manifest_v2.uuid, Manifest),
+    ObjectToWrite = case get_manifests(RiakcPid, Bucket, Key) of
+        {ok, RiakObject, Manifests} ->
+            NewManiAdded = stanchion_manifest_resolution:resolve([WrappedManifest, Manifests]),
+            OverriddenMarkedAsPendingDelete = stanchion_manifest:mark_overwritten(NewManiAdded),
+            riakc_obj:update_value(RiakObject, term_to_binary(OverriddenMarkedAsPendingDelete));
+        {error, notfound} ->
+            ManifestBucket = stanchion_utils:to_bucket_name(objects, Bucket),
+            riakc_obj:new(ManifestBucket, Key, term_to_binary(WrappedManifest))
+    end,
+
+    %% TODO:
+    %% currently we don't do
+    %% anything to make sure
+    %% this call succeeded
+    riakc_pb_socket:put(RiakcPid, ObjectToWrite).
+
+%% ===================================================================
+%% Test API
+%% ===================================================================
+
+-ifdef(TEST).
+
+test_link(Bucket, Key) ->
+    gen_fsm:start_link(?MODULE, [test, Bucket, Key], []).
+
+-endif.

--- a/src/stanchion_manifest_resolution.erl
+++ b/src/stanchion_manifest_resolution.erl
@@ -1,0 +1,123 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Module to resolve siblings with manifest records
+
+-module(stanchion_manifest_resolution).
+
+-include("riak_moss.hrl").
+
+%% export Public API
+-export([resolve/1]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Take a list of siblings
+%% and resolve them to a single
+%% value. In this case, siblings
+%% and values are dictionaries whose
+%% keys are UUIDs and whose values
+%% are manifests.
+-spec resolve(list()) -> term().
+resolve(Siblings) ->
+    lists:foldl(fun resolve_dicts/2, orddict:new(), Siblings).
+
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+
+%% @doc Take two dictionaries
+%% of manifests and resolve them.
+%% @private
+-spec resolve_dicts(term(), term()) -> term().
+resolve_dicts(A, B) ->
+    orddict:merge(fun resolve_manifests/3, A, B).
+
+%% @doc Take two manifests with
+%% the same UUID and resolve them
+%% @private
+-spec resolve_manifests(term(), term(), term()) -> term().
+resolve_manifests(_Key, A, B) ->
+    AState = A#lfs_manifest_v2.state,
+    BState = B#lfs_manifest_v2.state,
+    resolve_manifests(AState, BState, A, B).
+
+%% @doc Return a new, resolved manifest.
+%% The first two args are the state that
+%% manifest A and B are in, respectively.
+%% The third and fourth args, A, B, are the
+%% manifests themselves.
+%% @private
+-spec resolve_manifests(atom(), atom(), term(), term()) -> term().
+resolve_manifests(writing, writing, A, B) ->
+    WriteBlocksRemaining = resolve_written_blocks(A, B),
+    LastBlockWrittenTime = resolve_last_written_time(A, B),
+    A#lfs_manifest_v2{write_blocks_remaining=WriteBlocksRemaining, last_block_written_time=LastBlockWrittenTime};
+
+resolve_manifests(writing, active, _A, B) -> B;
+resolve_manifests(active, writing, A, B) ->
+    resolve_manifests(writing, active, B, A);
+
+resolve_manifests(writing, pending_delete, _A, B) -> B;
+resolve_manifests(pending_delete, writing, A, B) ->
+    resolve_manifests(writing, pending_delete, B, A);
+
+resolve_manifests(writing, deleted, _A, B) -> B;
+resolve_manifests(deleted, writing, A, B) ->
+   resolve_manifests(writing, deleted, B, A);
+
+%% purposely throw a function clause
+%% exception if the manifests aren't
+%% equivalent
+resolve_manifests(active, active, A, A) -> A;
+
+resolve_manifests(active, pending_delete, _A, B) -> B;
+resolve_manifests(pending_delete, active, A, B) ->
+    resolve_manifests(active, pending_delete, B, A);
+
+resolve_manifests(active, deleted, _A, B) -> B;
+resolve_manifests(deleted, active, A, B) ->
+    resolve_manifests(active, deleted, B, A);
+
+resolve_manifests(pending_delete, pending_delete, A, B) ->
+    BlocksLeftToDelete = resolve_deleted_blocks(A, B),
+    LastDeletedTime = resolve_last_deleted_time(A, B),
+    A#lfs_manifest_v2{delete_blocks_remaining=BlocksLeftToDelete, last_block_deleted_time=LastDeletedTime};
+resolve_manifests(pending_delete, deleted, _A, B) -> B;
+resolve_manifests(deleted, pending_delete, A, B) ->
+    resolve_manifests(pending_delete, deleted, B, A);
+
+resolve_manifests(deleted, deleted, A, A) -> A;
+resolve_manifests(deleted, deleted, A, B) ->
+    %% should this deleted date
+    %% be different than the last block
+    %% deleted date? I'm think yes, technically.
+    LastBlockDeletedTime = resolve_last_deleted_time(A, B),
+    A#lfs_manifest_v2{last_block_deleted_time=LastBlockDeletedTime}.
+
+resolve_written_blocks(A, B) ->
+    AWritten = A#lfs_manifest_v2.write_blocks_remaining,
+    BWritten = B#lfs_manifest_v2.write_blocks_remaining,
+    ordsets:intersection(AWritten, BWritten).
+
+resolve_deleted_blocks(A, B) ->
+    ADeleted = A#lfs_manifest_v2.delete_blocks_remaining,
+    BDeleted = B#lfs_manifest_v2.delete_blocks_remaining,
+    ordsets:intersection(ADeleted, BDeleted).
+
+resolve_last_written_time(A, B) ->
+    ALastWritten = A#lfs_manifest_v2.last_block_written_time,
+    BLastWritten = B#lfs_manifest_v2.last_block_written_time,
+    latest_date(ALastWritten, BLastWritten).
+
+resolve_last_deleted_time(A, B) ->
+    ALastDeleted = A#lfs_manifest_v2.last_block_deleted_time,
+    BLastDeleted = B#lfs_manifest_v2.last_block_deleted_time,
+    latest_date(ALastDeleted, BLastDeleted).
+
+latest_date(A, B) -> erlang:max(A, B).

--- a/src/stanchion_utils.erl
+++ b/src/stanchion_utils.erl
@@ -34,10 +34,10 @@
 -include("stanchion.hrl").
 -include_lib("riakc/include/riakc_obj.hrl").
 
--define(OBJECT_BUCKET_PREFIX, <<"objects:">>).
--define(BLOCK_BUCKET_PREFIX, <<"blocks:">>).
 -define(EMAIL_INDEX, <<"email_bin">>).
 -define(ID_INDEX, <<"c_id_bin">>).
+-define(OBJECT_BUCKET_PREFIX, <<"0o:">>).       % Version # = 0
+-define(BLOCK_BUCKET_PREFIX, <<"0b:">>).        % Version # = 0
 
 %% ===================================================================
 %% Public API
@@ -294,10 +294,28 @@ to_bucket_name(blocks, Name) ->
 %% @doc Check if a bucket is empty
 -spec bucket_empty(binary(), pid()) -> boolean().
 bucket_empty(Bucket, RiakPid) ->
-    ObjBucket = to_bucket_name(objects, Bucket),
-    case list_keys(ObjBucket, RiakPid) of
-        {ok, []} ->
-            true;
+    ManifestBucket = to_bucket_name(objects, Bucket),
+    %% @TODO Use `stream_list_keys' instead and
+    %% break out as soon as an active manifest is found.
+    case list_keys(ManifestBucket, RiakPid) of
+        {ok, Keys} ->
+            FoldFun =
+                fun(Key, Acc) ->
+                        {ok, ManiPid} = stanchion_manifest_fsm:start_link(Bucket, Key),
+                        case stanchion_manifest_fsm:get_active_manifest(ManiPid) of
+                            {ok, _} ->
+                                [Key | Acc];
+                            {error, notfound} ->
+                                Acc
+                        end
+                end,
+            ActiveKeys = lists:foldl(FoldFun, [], Keys),
+            case ActiveKeys of
+                [] ->
+                    true;
+                _ ->
+                    false
+            end;
         _ ->
             false
     end.


### PR DESCRIPTION
Add renamed copies of manifest module for riak_moss repo to support proper checks for when a bucket may be deleted. Use the manifest_fsm to check active manifests to determine if a bucket may be deleted. Using renamed copies of the `riak_moss` modules is a crude way to handle this and hopefully in the near future we will better consolidate our shared code.
## Testing

Using `master` of moss and stanchion, create a bucket, store a file in the bucket, delete the file from the bucket, and then attempt to delete the bucket. It will fail. Switch to the `s180-fix-bucket-deletion` branch for moss and stanchion and now the bucket deletion should succeed.
