### PR TITLE
ACL ownership information update

### DIFF
--- a/include/stanchion.hrl
+++ b/include/stanchion.hrl
@@ -23,12 +23,16 @@
 -type acl_perm() :: 'READ' | 'WRITE' | 'READ_ACP' | 'WRITE_ACP' | 'FULL_CONTROL'.
 -type acl_perms() :: [acl_perm()].
 -type acl_grant() :: {{string(), string()}, acl_perms()}.
--record(acl_v1, {owner={"", ""} :: {string(), string()},
+-type acl_owner() :: {string(), string()} | {string(), string(), string()}.
+-record(acl_v1, {owner={"", ""} :: acl_owner(),
                  grants=[] :: [acl_grant()],
                  creation_time=now() :: erlang:timestamp()}).
--type acl() :: #acl_v1{}.
+-record(acl_v2, {owner={"", "", ""} :: acl_owner(),
+                 grants=[] :: [acl_grant()],
+                 creation_time=now() :: erlang:timestamp()}).
+-type acl() :: #acl_v1{} | #acl_v2{}.
 
--define(ACL, #acl_v1).
+-define(ACL, #acl_v2).
 -define(USER_BUCKET, <<"moss.users">>).
 -define(BUCKETS_BUCKET, <<"moss.buckets">>).
 -define(FREE_BUCKET_MARKER, <<"0">>).


### PR DESCRIPTION
These changes add an `acl_v2` record and make the changes necessary to include the user's `key_id` as part of the acl ownership information. The reason behind this is to eliminate the need for an expensive 2I query on each object put request and to only use the secondary index to look up user by `canonical_id` when absolutely necessary. These changes are backward compatible so existing buckets and objects with `acl_v1` ACLs will continue to work. 
