### PR TITLE
Fix vars.config variables so relative paths are used.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ stage : rel
 	$(foreach dep,$(wildcard deps/*), rm -rf rel/stanchion/lib/$(shell basename $(dep))-* && ln -sf $(abspath $(dep)) rel/stanchion/lib;)
 	$(foreach app,$(wildcard apps/*), rm -rf rel/stanchion/lib/$(shell basename $(app))-* && ln -sf $(abspath $(app)) rel/stanchion/lib;)
 
-devrel:
+devrel: all
 	mkdir -p dev
 	(cd rel && ../rebar generate target_dir=../dev/$(REPO) overlay_vars=vars.config)
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ stage : rel
 
 devrel:
 	mkdir -p dev
-	(cd rel && ../rebar generate target_dir=../dev/$(REPO) overlay_vars=vars/dev_vars.config)
+	(cd rel && ../rebar generate target_dir=../dev/$(REPO) overlay_vars=vars.config)
 
 devclean: clean
 	rm -rf dev

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 {reset_after_eunit, true}.
 
 {deps, [
-        {node_package, ".*", {git, "/Users/jared/Development/basho/node_package-master", {branch, "jem-osx-packaging"}}},
+        {node_package, ".*", {git, "git@github.com:basho/node_package", {branch, "master"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "master"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}}

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -2,10 +2,6 @@
 %% ex: ts=4 sw=4 et
 
 %% Platform-specific installation paths
-{platform_bin_dir,  "./bin"}.
-{platform_data_dir, "./data"}.
-{platform_etc_dir,  "./etc"}.
-{platform_lib_dir,  "./lib"}.
 {platform_log_dir,  "./log"}.
 
 %%
@@ -31,10 +27,9 @@
 %% bin/stanchion
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/sbin"}.
-{runner_bin_dir,     "{{target_dir}}"}.
-{runner_run_dir,     "{{target_dir}}"}.
-{runner_etc_dir,     "{{target_dir}}/etc"}.
-{runner_log_dir,     "{{target_dir}}/log"}.
-{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_base_dir,    "{{runner_script_dir}}/.."}.
+{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
+{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
+{pipe_dir,           "/tmp/stanchion/"}.
 {runner_user,        ""}.


### PR DESCRIPTION
Absolute paths were used throughout the vars.config variables
which caused both `make rel` and package creation to have
fixed paths in the runner scripts and settings.  This didn't
enable moving installations around (`make devrel`) and
caused packaging to have incorrect paths throughout.
