### PR TITLE
Correctly calculate md5 for HTTP requests

### DIFF
--- a/src/velvet.erl
+++ b/src/velvet.erl
@@ -284,8 +284,7 @@ request(Method, Url, Expect, ContentType, Headers, Body) ->
 %% @doc Calculate an MD5 hash of a request body.
 -spec content_md5(string()) -> string().
 content_md5(Body) ->
-    stanchion_utils:binary_to_hexlist(
-      list_to_binary(Body)).
+    stanchion_utils:binary_to_hexlist(crypto:md5(list_to_binary(Body))).
 
 %% @doc Construct a MOSS authentication header
 -spec auth_header(atom(),


### PR DESCRIPTION
We've been incorrectly calculating the 'Content-Md5' for requests from riak-cs -> stanchion. This wasn't a problem until we started [checking for correct md5](https://github.com/basho/webmachine/commit/8ad2a72812ba578d12fcf9e2515fe377e4249aac) in webmachine. The last release of stanchion _also_ relied on webmachine _master_, instead of a specific tag. So this error will come up when using both a tagged version of Riak CS _and_ stanchion.
