### PR TITLE
Use infinity timeout for `gen_server:call/3` in stanchion_server

### DIFF
--- a/src/stanchion_server.erl
+++ b/src/stanchion_server.erl
@@ -52,7 +52,7 @@ start_link() ->
 %% @doc Attempt to create a bucket
 -spec create_bucket([{term(), term()}]) -> ok | {error, term()}.
 create_bucket(BucketData) ->
-    gen_server:call(?MODULE, {create_bucket, BucketData}).
+    gen_server:call(?MODULE, {create_bucket, BucketData}, infinity).
 
 %% @doc Attempt to create a bucket
 -spec create_user([{term(), term()}]) ->
@@ -60,12 +60,12 @@ create_bucket(BucketData) ->
                          {error, term()} |
                          {error, stanchion_utils:riak_connect_failed()}.
 create_user(UserData) ->
-    gen_server:call(?MODULE, {create_user, UserData}).
+    gen_server:call(?MODULE, {create_user, UserData}, infinity).
 
 %% @doc Attempt to delete a bucket
 -spec delete_bucket(binary(), binary()) -> ok | {error, term()}.
 delete_bucket(Bucket, UserId) ->
-    gen_server:call(?MODULE, {delete_bucket, Bucket, UserId}).
+    gen_server:call(?MODULE, {delete_bucket, Bucket, UserId}, infinity).
 
 stop(Pid) ->
     gen_server:cast(Pid, stop).


### PR DESCRIPTION
This was causing timeouts for large bucket deletes, like
this:

```
2012-11-06 19:12:40.260 UTC [error] <0.132.0> webmachine error:
path="/buckets/REDACTED-BUCKET"
{exit,{timeout,{gen_server,call,[stanchion_server,{delete_bucket,<<"REDACTED-BUCKET">>,<<"REDACTED-KEY">>}]}},[{gen_server,call,2,[{file,"gen_server.erl"},{line,180}]},{stanchion_wm_bucket,delete_resource,2,[{file,"src/stanchion_wm_bucket.erl"},{line,110}]},{webmachine_resource,resource_call,3,[{file,"src/webmachine_resource.erl"},{line,169}]},{webmachine_resource,do,3,[{file,"src/webmachine_resource.erl"},{line,128}]},{webmachine_decision_core,resource_call,1,[{file,"src/webmachine_decision_core.erl"},{line,48}]},{webmachine_decision_core,decision,1,[{file,"src/webmachine_decision_core.erl"},{line,416}]},{webmachine_decision_core,handle_request,2,[{file,"src/webmachine_decision_core.erl"},{line,33}]},{webmachine_mochiweb,loop,1,[{file,"src/webmachine_mochiweb.erl"},{line,87}]}]}
```
