### PR TITLE
Copy runner script into `bin` rather than `sbin`

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -49,7 +49,7 @@
            {copy, "../deps/node_package/priv/base/nodetool",
             "{{erts_vsn}}/bin/nodetool"},
            {template, "../deps/node_package/priv/base/runner",
-            "sbin/stanchion"},
+            "bin/stanchion"},
            {template, "../deps/node_package/priv/base/env.sh",
             "lib/env.sh"},
 


### PR DESCRIPTION
Reltool forces a `bin` directory to be created, so this change
just uses that standard.  `node_package` will copy the binary
into `sbin` anyway with the `bin_or_sbin` setting in the
`pkg.vars.config` file.
