### PR TITLE
cleanup riak_test stanchion setup script

### DIFF
--- a/riak_test/bin/rtdev-setup-releases.sh
+++ b/riak_test/bin/rtdev-setup-releases.sh
@@ -5,14 +5,28 @@
 # that contains devrels for prior Riak CS releases. Easy way to create this
 # is to use the rtdev-build-releases.sh script
 
-rm -rf /tmp/rtstanchion
-mkdir /tmp/rtstanchion
+: ${STANCHION_DEST_DIR:="$HOME/rt/stanchion"}
+mkdir -p $STANCHION_DEST_DIR
+
+echo "Setting up releases from $(pwd):"
+echo " - Creating $STANCHION_DEST_DIR"
+
+rm -rf $STANCHION_DEST_DIR
+mkdir -p $STANCHION_DEST_DIR
 for rel in */dev; do
     vsn=$(dirname "$rel")
-    mkdir "/tmp/rtstanchion/$vsn"
-    cp -a "$rel" "/tmp/rtstanchion/$vsn"
+    echo " - Initializing $STANCHION_DEST_DIR/$vsn"
+    mkdir "$STANCHION_DEST_DIR/$vsn"
+    cp -p -P -R "$rel" "$STANCHION_DEST_DIR/$vsn"
 done
-cd /tmp/rtstanchion
-git init
+cd $STANCHION_DEST_DIR
+echo " - Creating rt stanchion git repository"
+git init > /dev/null 2>&1
+
+## Some versions of git and/or OS require these fields
+git config user.name "Riak Test"
+git config user.email "dev@basho.com"
+
 git add .
-git commit -a -m "riak_test init"
+git commit -a -m "riak_test init" > /dev/null 2>&1
+


### PR DESCRIPTION
riak_test/bin/rtdev-setup-releases.sh was still putting stanchion in /tmp/rtstanchion. I changed it to the standardized directory ~/HOME/rt/stanchion, and applied some cleanup from the riak_ee setup script.
