### PR TITLE
Fix issues caused by bad merge of 7302e5b

### DIFF
--- a/src/stanchion_server.erl
+++ b/src/stanchion_server.erl
@@ -124,10 +124,10 @@ handle_call({create_user, UserData},
             State=#state{}) ->
     Result = stanchion_utils:create_user(UserData),
     {reply, Result, State};
-handle_call({update_user, UserData},
+handle_call({update_user, KeyId, UserData},
             _From,
             State=#state{}) ->
-    Result = stanchion_utils:update_user(UserData),
+    Result = stanchion_utils:update_user(KeyId, UserData),
     {reply, Result, State};
 handle_call({delete_bucket, Bucket, OwnerId},
             _From,


### PR DESCRIPTION
The merge of 7302e5b introduced issues after the branch was mistakenly merged
to master and then deleted. The branch was reassembled, but the reassembly was
incomplete and introduced bugs causing user updates to fail to function
correctly. This change completes the changes form the original branch and
fixes the issues with user updates.

The `user_test` is failing on `develop` and these changes correct the errors causing the failures.
