### PR TITLE
Update stanchion depedencies for 1.4 release

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,9 +11,9 @@
 {reset_after_eunit, true}.
 
 {deps, [
-        {node_package, "1.3.1", {git, "git://github.com/basho/node_package", {tag, "1.3.1"}}},
-        {webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", {tag, "1.10.0"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.1.1"}}},
-        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "1.2.2"}}},
+        {node_package, "1.3.2", {git, "git://github.com/basho/node_package", {tag, "1.3.2"}}},
+        {webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", {tag, "1.10.3"}}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.0"}}},
+        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "3280b736057a6cf5c01590c79fd192f7e8645270"}}
        ]}.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -35,10 +35,16 @@
           %% consists of {Logfile, Level}.
           {handlers, [
                       {lager_console_backend, info},
-                      {lager_file_backend, [
-                                            {"{{platform_log_dir}}/error.log", error, 10485760, "$D0", 5},
-                                            {"{{platform_log_dir}}/console.log", info, 10485760, "$D0", 5}
-                                           ]}
+                      {lager_file_backend, [{file, "{{platform_log_dir}}/error.log"},
+                                            {level, error},
+                                            {size, 10485760},
+                                            {date, "$D0"},
+                                            {count, 5}]},
+                      {lager_file_backend, [{file, "{{platform_log_dir}}/console.log"},
+                                            {level, info},
+                                            {size, 10485760},
+                                            {date, "$D0"},
+                                            {count, 5}]}
                      ]},
 
           %% Whether to write a crash log, and where.

--- a/src/stanchion_utils.erl
+++ b/src/stanchion_utils.erl
@@ -52,6 +52,7 @@
          update_user/2]).
 
 -include("stanchion.hrl").
+-include_lib("riakc/include/riakc.hrl").
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
 
 -define(EMAIL_INDEX, <<"email_bin">>).
@@ -609,8 +610,8 @@ do_bucket_op(Bucket, OwnerId, AclOrPolicy, BucketOp) ->
 %% assurance that a particular email address is available.
 -spec email_available(binary(), pid()) -> true | {false, term()}.
 email_available(Email, RiakPid) ->
-    case riakc_pb_socket:get_index(RiakPid, ?USER_BUCKET, ?EMAIL_INDEX, Email) of
-        {ok, []} ->
+    case riakc_pb_socket:get_index_eq(RiakPid, ?USER_BUCKET, ?EMAIL_INDEX, Email) of
+        {ok, ?INDEX_RESULTS{keys=[]}} ->
             true;
         {ok, _} ->
             {false, user_already_exists};


### PR DESCRIPTION
Update the dependency levels for node_package, webmachine, lager, and 
riak-erlang-client in preparation for the 1.4 release.
