### PR TITLE
Fix rebar.config.script check for OTP version

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,4 +1,4 @@
-case erlang:system_info(otp_release) =< "R15B01" of
+case erlang:system_info(otp_release) < "R16" of
     true ->
         CONFIG;
     false ->


### PR DESCRIPTION
Some new functions were added to the crypto API after R15B01, but the hmac/3
and hmac/4 functions did not arrive until R16. Only set new_hash if the OTP
version is R16 or above.
