### PR TITLE
Fix path substitution code to fix Solaris source builds

### DIFF
--- a/rel/vars.config
+++ b/rel/vars.config
@@ -31,7 +31,7 @@
 %% bin/stanchion
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_script_dir,  "\`cd \\`dirname $0\\` && /bin/pwd\`"}.
 {runner_base_dir,    "{{runner_script_dir}}/.."}.
 {runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
 {runner_log_dir,     "$RUNNER_BASE_DIR/log"}.


### PR DESCRIPTION
Addresses: basho/riak#439

This riak bug would also be a concern with source Stanchion builds
