### PR TITLE
Upgrade to lager 2.0.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,5 +15,6 @@
         {webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", {tag, "1.10.3"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.1"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.1"}}},
+        {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.1"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "3280b736057a6cf5c01590c79fd192f7e8645270"}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,6 @@
         {node_package, "1.3.8", {git, "git://github.com/basho/node_package", {tag, "1.3.8"}}},
         {webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", {tag, "1.10.3"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.1"}}},
-        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},
+        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.1"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "3280b736057a6cf5c01590c79fd192f7e8645270"}}
        ]}.


### PR DESCRIPTION
Upgrade to lager 2.0.1 to pull in a tracing fix. Also add lager_syslog so that logging to syslog can optionally be enabled.
