### PR TITLE
fixed 'Missing application directory.'

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -29,7 +29,7 @@
        {excl_archive_filters, [".*"]},
        {app, sasl, [{incl_cond, include}]},
        {app, lager, [{incl_cond, include}]},
-       {app, stanchion, [{incl_cond, include}]}
+       {app, stanchion, [{incl_cond, include}, {lib_dir, ".."}]}
       ]}.
 
 


### PR DESCRIPTION
fixed following error

```
$ make rel
......
==> stanchion (compile)
==> rel (generate)
ERROR: generate failed while processing foo/bar/stanchion/rel: {'EXIT',{{badmatch,{error,"stanchion: Missing application directory."}},
         [{rebar_reltool,generate,2,
                         [{file,"src/rebar_reltool.erl"},{line,53}]},
          {rebar_core,run_modules,4,[{file,"src/rebar_core.erl"},{line,446}]},
          {rebar_core,execute,5,[{file,"src/rebar_core.erl"},{line,371}]},
          {rebar_core,process_dir1,6,[{file,"src/rebar_core.erl"},{line,235}]},
          {rebar_core,process_each,5,[{file,"src/rebar_core.erl"},{line,305}]},
          {rebar_core,process_dir1,6,[{file,"src/rebar_core.erl"},{line,211}]},
          {rebar_core,process_commands,2,
                      [{file,"src/rebar_core.erl"},{line,90}]},
          {rebar,main,1,[{file,"src/rebar.erl"},{line,58}]}]}}
make: *** [rel] 오류 1
```

environment:
rebar 2.5.0 R14B 20140623_185150 git 2.5.0
Erlang R16B03-1 (erts-5.10.4) [source] [64-bit] [smp:16:16] [async-threads:10] [hipe] [kernel-poll:false]

ref: https://groups.google.com/forum/m/?fromgroups#!topic/erlang-programming/fr5ccgnBSck
