### PR TITLE
Add stats to Stanchion

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,6 +19,7 @@
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.0"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.3"}}},
+        {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {tag, "1.2"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish", {tag, "2.0.1"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "0.78"}}
        ]}.

--- a/rel/files/stanchion-admin
+++ b/rel/files/stanchion-admin
@@ -1,0 +1,32 @@
+#!/bin/sh
+# -*- tab-width:4;indent-tabs-mode:nil -*-
+# ex: ts=4 sw=4 et
+
+# Pull environment for this install
+. "{{runner_base_dir}}/lib/env.sh"
+
+# Make sure the user running this script is the owner and/or su to that user
+check_user "$@"
+
+# Make sure CWD is set to runner run dir
+cd $RUNNER_BASE_DIR
+
+# Identify the script name
+SCRIPT=`basename $0`
+
+usage() {
+    echo "Usage: $SCRIPT { status }"
+}
+
+# Check the first argument for instructions
+case "$1" in
+    status)
+        shift
+        node_up_check
+        $NODETOOL rpc stanchion_console status
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -16,6 +16,7 @@
          webmachine,
          lager,
          lager_syslog,
+         exometer_core,
          stanchion
         ]},
        {rel, "start_clean", "",
@@ -65,6 +66,7 @@
            {template, "../deps/cuttlefish/priv/erlang_vm.schema", "lib/11-erlang_vm.schema"},
 
            {template, "files/advanced.config", "etc/advanced.config"},
+           {template, "files/stanchion-admin", "bin/stanchion-admin"},
 
            %% Copy ssl certs
            {template, "files/cert.pem", "etc/cert.pem"},

--- a/src/stanchion_console.erl
+++ b/src/stanchion_console.erl
@@ -1,0 +1,33 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc Callbacks for the stanchion application.
+
+-module(stanchion_console).
+
+-export([status/1]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+status(_) ->
+    Stats = stanchion_stats:get_stats(),
+    [io:format("~s : ~p~n", [Key,Value]) || {Key,Value} <- Stats],
+    ok.

--- a/src/stanchion_server.erl
+++ b/src/stanchion_server.erl
@@ -42,7 +42,7 @@
          set_bucket_acl/2,
          stop/1,
          update_user/2,
-         msg_q_len/0]).
+         msgq_len/0]).
 
 %% gen_server callbacks
 -export([init/1,
@@ -91,9 +91,9 @@ start_link() ->
 -spec create_bucket([{term(), term()}]) -> ok | {error, term()}.
 create_bucket(BucketData) ->
     ?MEASURE([bucket, create],
-             (gen_server:call(?MODULE,
-                              {create_bucket, BucketData},
-                              infinity))).
+             gen_server:call(?MODULE,
+                             {create_bucket, BucketData},
+                             infinity)).
 
 %% @doc Attempt to create a bucket
 -spec create_user([{term(), term()}]) ->
@@ -101,25 +101,26 @@ create_bucket(BucketData) ->
                          {error, term()} |
                          {error, stanchion_utils:riak_connect_failed()}.
 create_user(UserData) ->
-    ?MEASURE([user, create], (gen_server:call(?MODULE,
-                                              {create_user, UserData},
-                                              infinity))).
+    ?MEASURE([user, create],
+             gen_server:call(?MODULE,
+                             {create_user, UserData},
+                             infinity)).
 
 %% @doc Attempt to delete a bucket
 -spec delete_bucket(binary(), binary()) -> ok | {error, term()}.
 delete_bucket(Bucket, UserId) ->
     ?MEASURE([bucket, delete],
-             (gen_server:call(?MODULE,
-                              {delete_bucket, Bucket, UserId},
-                              infinity))).
+             gen_server:call(?MODULE,
+                             {delete_bucket, Bucket, UserId},
+                             infinity)).
 
 %% @doc Set the ACL for a bucket
 -spec set_bucket_acl(binary(), term()) -> ok | {error, term()}.
 set_bucket_acl(Bucket, FieldList) ->
     ?MEASURE([bucket, put_acl],
-             (gen_server:call(?MODULE,
-                              {set_acl, Bucket, FieldList},
-                              infinity))).
+             gen_server:call(?MODULE,
+                             {set_acl, Bucket, FieldList},
+                             infinity)).
 
 stop(Pid) ->
     gen_server:cast(Pid, stop).
@@ -131,12 +132,12 @@ stop(Pid) ->
                          {error, stanchion_utils:riak_connect_failed()}.
 update_user(KeyId, UserData) ->
     ?MEASURE([user, update],
-             (gen_server:call(?MODULE,
-                              {update_user, KeyId, UserData},
-                              infinity))).
+             gen_server:call(?MODULE,
+                             {update_user, KeyId, UserData},
+                             infinity)).
 
--spec msg_q_len() -> non_neg_integer().
-msg_q_len() ->
+-spec msgq_len() -> non_neg_integer().
+msgq_len() ->
     Pid = whereis(?MODULE),
     {message_queue_len, Len} = erlang:process_info(Pid, message_queue_len),
     Len.

--- a/src/stanchion_server.erl
+++ b/src/stanchion_server.erl
@@ -73,7 +73,7 @@
             {{Result_____, ServiceTime____},
              TATus_____} = ?TURNAROUND_TIME(Call),
             WaitingTime____ = TATus_____ - ServiceTime____,
-            lager:info("~p ~p ~p", [Name, Result_____, ServiceTime____]),
+            _ = lager:debug("~p ~p ~p", [Name, Result_____, ServiceTime____]),
             stanchion_stats:update(Name, ServiceTime____, WaitingTime____),
             Result_____
         end).

--- a/src/stanchion_stats.erl
+++ b/src/stanchion_stats.erl
@@ -1,0 +1,205 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(stanchion_stats).
+
+%% API
+-export([safe_update/2,
+         update/2,
+         update/3,
+         update_with_start/2,
+         report_json/0,
+         %% report_pretty_json/0,
+         get_stats/0]).
+
+-export([init/0]).
+
+-type metric_name() :: list(atom()).
+-export_type([metric_name/0]).
+
+-define(METRICS,
+        %% [{metric_name(), exometer:type(), [exometer:option()], Aliases}]
+        [{[bucket, create], spiral, [],
+          [{one, bucket_creates}, {count, bucket_creates_total}]},
+         {[bucket, delete], spiral, [],
+          [{one, bucket_deletes}, {count, bucket_deletes_total}]},
+         {[bucket, put_acl], spiral, [],
+          [{one, bucket_put_acl}, {count, bucket_put_acl_total}]},
+
+         {[bucket, create, time], histogram, [],
+          [{mean  , bucket_create_time_mean},
+           {median, bucket_create_time_median},
+           {95    , bucket_create_time_95},
+           {99    , bucket_create_time_99},
+           {100   , bucket_create_time_100}]},
+         {[bucket, delete, time], histogram, [],
+          [{mean  , bucket_delete_time_mean},
+           {median, bucket_delete_time_median},
+           {95    , bucket_delete_time_95},
+           {99    , bucket_delete_time_99},
+           {100   , bucket_delete_time_100}]},
+         {[bucket, put_acl, time], histogram, [],
+          [{mean  , bucket_put_acl_time_mean},
+           {median, bucket_put_acl_time_median},
+           {95    , bucket_put_acl_time_95},
+           {99    , bucket_put_acl_time_99},
+           {100   , bucket_put_acl_time_100}]},
+
+         {[user, create], spiral, [],
+          [{one, user_create}, {count, user_create_total}]},
+         {[user, update], spiral, [],
+          [{one, user_update}, {count, user_update_total}]},
+
+         {[user, create, time], histogram, [],
+          [{mean  , user_create_time_mean},
+           {median, user_create_time_median},
+           {95    , user_create_time_95},
+           {99    , user_create_time_99},
+           {100   , user_create_time_100}]},
+         {[user, update, time], histogram, [],
+          [{mean  , user_update_time_mean},
+           {median, user_update_time_median},
+           {95    , user_update_time_95},
+           {99    , user_update_time_99},
+           {100   , user_update_time_100}]},
+         
+         {[waiting, time], histogram, [],
+          [{mean  , waiting_time_mean},
+           {median, waiting_time_median},
+           {95    , waiting_time_95},
+           {99    , waiting_time_99},
+           {100   , waiting_time_100}]}
+        ]).
+
+%% ====================================================================
+%% API
+%% ====================================================================
+
+
+
+-spec safe_update(metric_name(), integer()) -> ok | {error, any()}.
+safe_update(BaseId, ElapsedUs) ->
+    %% Just in case those metrics happen to be not registered; should
+    %% be a bug and also should not interrupt handling requests by
+    %% crashing.
+    try
+        update(BaseId, ElapsedUs)
+    catch T:E ->
+            lager:error("Failed on storing some metrics: ~p,~p", [T,E])
+    end.
+
+-spec update(metric_name(), integer()) -> ok | {error, any()}.
+update(BaseId, ElapsedUs) ->
+    ok = exometer:update([stanchion|BaseId], 1),
+    ok = exometer:update([stanchion|BaseId]++[time], ElapsedUs).
+
+update(BaseId, ServiceTime, WaitingTime) ->
+    update(BaseId, ServiceTime),
+    ok = exometer:update([stanchion, waiting, time], WaitingTime).
+
+-spec update_with_start(metric_name(), erlang:timestamp()) ->
+                                   ok | {error, any()}.
+update_with_start(BaseId, StartTime) ->
+    update(BaseId, timer:now_diff(os:timestamp(), StartTime)).
+
+-spec report_json() -> string().
+report_json() ->
+    lists:flatten(mochijson2:encode({struct, get_stats()})).
+
+-spec get_stats() -> proplists:proplist().
+get_stats() ->
+    Stats1 = [raw_report_item(I) || I <- ?METRICS],
+    Stats2 = [{stanchion_server_msg_q_len, stanchion_server:msg_q_len()}],
+    lists:flatten(Stats2 ++ Stats1).
+
+init() ->
+    _ = [init_item(I) || I <- ?METRICS],
+    ok.
+
+%% ====================================================================
+%% Internal
+%% ====================================================================
+
+init_item({Name, Type, Opts, Aliases}) ->
+    ok = exometer:re_register([stanchion|Name], Type,
+                              [{aliases, Aliases}|Opts]).
+
+raw_report_item({Name, _Type, _Options, Aliases}) ->
+
+    {ok, Values} = exometer:get_value([stanchion|Name], [D||{D,_Alias}<-Aliases]),
+    [{Alias, Value} ||
+        {{D, Alias}, {D, Value}} <- lists:zip(Aliases, Values)].
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+stats_metric_test() ->
+    [begin
+         ?debugVal(Key),
+         case lists:last(Key) of
+             time ->
+                 ?assertEqual(histogram, Type),
+                 [?assert(proplists:is_defined(M, Aliases))
+                  || M <- [mean, median, 95, 99, 100]];
+             _ ->
+                 ?assertNotEqual(false, lists:keyfind(Key, 1, ?METRICS)),
+                 ?assertEqual(spiral, Type),
+                 ?assert(proplists:is_defined(one, Aliases)),
+                 ?assert(proplists:is_defined(count, Aliases))
+         end,
+         ?assertEqual([], Options)
+     end || {Key, Type, Options, Aliases} <- ?METRICS].
+
+stats_test_() ->
+    Apps = [setup, compiler, syntax_tools, goldrush, lager, exometer_core],
+    {setup,
+     fun() ->
+             [ok = application:start(App) || App <- Apps],
+             ok = stanchion_stats:init()
+     end,
+     fun(_) ->
+             [ok = application:stop(App) || App <- Apps]
+     end,
+     [{inparallel, [fun() ->
+                            %% ?debugVal(Key),
+                            case lists:last(Key) of
+                                time -> ok;
+                                _ -> stanchion_stats:update(Key, 16#deadbeef, 16#deadbeef)
+                            end
+                    end || {Key, _, _, _} <- ?METRICS]},
+     fun() ->
+             [begin
+                  Items = raw_report_item(I),
+                  ?debugVal(Items),
+                  case length(Items) of
+                      2 ->
+                          ?assertEqual([1, 1],
+                                       [N || {_, N} <- Items]);
+                      5 ->
+                          %% TODO: some_metric_100 also should be 16#deadebeef
+                          %% something is wrong now, also in riak_cs
+                          ?assertEqual([16#deadbeef, 16#deadbeef, 16#deadbeef, 16#deadbeef, 0],
+                                       [N || {_, N} <- Items])
+                  end
+              end || I <- ?METRICS]
+     end]}.
+
+-endif.

--- a/src/stanchion_stats.erl
+++ b/src/stanchion_stats.erl
@@ -48,44 +48,44 @@
            {median, bucket_create_time_median},
            {95    , bucket_create_time_95},
            {99    , bucket_create_time_99},
-           {100   , bucket_create_time_100}]},
+           {max   , bucket_create_time_100}]},
          {[bucket, delete, time], histogram, [],
           [{mean  , bucket_delete_time_mean},
            {median, bucket_delete_time_median},
            {95    , bucket_delete_time_95},
            {99    , bucket_delete_time_99},
-           {100   , bucket_delete_time_100}]},
+           {max   , bucket_delete_time_100}]},
          {[bucket, put_acl, time], histogram, [],
           [{mean  , bucket_put_acl_time_mean},
            {median, bucket_put_acl_time_median},
            {95    , bucket_put_acl_time_95},
            {99    , bucket_put_acl_time_99},
-           {100   , bucket_put_acl_time_100}]},
+           {max   , bucket_put_acl_time_100}]},
 
          {[user, create], spiral, [],
-          [{one, user_create}, {count, user_create_total}]},
+          [{one, user_creates}, {count, user_creates_total}]},
          {[user, update], spiral, [],
-          [{one, user_update}, {count, user_update_total}]},
+          [{one, user_updates}, {count, user_updates_total}]},
 
          {[user, create, time], histogram, [],
           [{mean  , user_create_time_mean},
            {median, user_create_time_median},
            {95    , user_create_time_95},
            {99    , user_create_time_99},
-           {100   , user_create_time_100}]},
+           {max   , user_create_time_100}]},
          {[user, update, time], histogram, [],
           [{mean  , user_update_time_mean},
            {median, user_update_time_median},
            {95    , user_update_time_95},
            {99    , user_update_time_99},
-           {100   , user_update_time_100}]},
+           {max   , user_update_time_100}]},
          
          {[waiting, time], histogram, [],
           [{mean  , waiting_time_mean},
            {median, waiting_time_median},
            {95    , waiting_time_95},
            {99    , waiting_time_99},
-           {100   , waiting_time_100}]}
+           {max   , waiting_time_100}]}
         ]).
 
 %% ====================================================================
@@ -127,7 +127,7 @@ report_json() ->
 get_stats() ->
     Stats1 = [raw_report_item(I) || I <- ?METRICS],
     Stats2 = [{stanchion_server_msg_q_len, stanchion_server:msg_q_len()}],
-    lists:flatten(Stats2 ++ Stats1).
+    Stats2 ++ lists:flatten(Stats1).
 
 init() ->
     _ = [init_item(I) || I <- ?METRICS],
@@ -158,7 +158,7 @@ stats_metric_test() ->
              time ->
                  ?assertEqual(histogram, Type),
                  [?assert(proplists:is_defined(M, Aliases))
-                  || M <- [mean, median, 95, 99, 100]];
+                  || M <- [mean, median, 95, 99, max]];
              _ ->
                  ?assertNotEqual(false, lists:keyfind(Key, 1, ?METRICS)),
                  ?assertEqual(spiral, Type),
@@ -194,9 +194,7 @@ stats_test_() ->
                           ?assertEqual([1, 1],
                                        [N || {_, N} <- Items]);
                       5 ->
-                          %% TODO: some_metric_100 also should be 16#deadebeef
-                          %% something is wrong now, also in riak_cs
-                          ?assertEqual([16#deadbeef, 16#deadbeef, 16#deadbeef, 16#deadbeef, 0],
+                          ?assertEqual([16#deadbeef, 16#deadbeef, 16#deadbeef, 16#deadbeef, 16#deadbeef],
                                        [N || {_, N} <- Items])
                   end
               end || I <- ?METRICS]

--- a/src/stanchion_stats.erl
+++ b/src/stanchion_stats.erl
@@ -126,8 +126,8 @@ report_json() ->
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
     Stats1 = [raw_report_item(I) || I <- ?METRICS],
-    Stats2 = [{stanchion_server_msg_q_len, stanchion_server:msg_q_len()}],
-    Stats2 ++ lists:flatten(Stats1).
+    Stats2 = [{stanchion_server_msgq_len, stanchion_server:msgq_len()}],
+    lists:flatten(Stats2 ++ Stats1).
 
 init() ->
     _ = [init_item(I) || I <- ?METRICS],

--- a/src/stanchion_sup.erl
+++ b/src/stanchion_sup.erl
@@ -53,6 +53,8 @@ init([]) ->
         undefined -> {"0.0.0.0", 80}
     end,
 
+    stanchion_stats:init(),
+    
     %% Create child specifications
     WebConfig1 = [
                  {dispatch, stanchion_web:dispatch_table()},

--- a/src/stanchion_web.erl
+++ b/src/stanchion_web.erl
@@ -36,5 +36,6 @@ dispatch_table() ->
      {["buckets", bucket, "policy"], stanchion_wm_policy, [{auth_bypass, AuthBypass}]},
      {["buckets", bucket], stanchion_wm_bucket, [{auth_bypass, AuthBypass}]},
      {["users", key_id], stanchion_wm_user, [{auth_bypass, AuthBypass}]},
-     {["users"], stanchion_wm_users, [{auth_bypass, AuthBypass}]}
+     {["users"], stanchion_wm_users, [{auth_bypass, AuthBypass}]},
+     {["stats"], stanchion_wm_stats, [{auth_bypass, AuthBypass}]}
     ].

--- a/src/stanchion_wm_stats.erl
+++ b/src/stanchion_wm_stats.erl
@@ -1,0 +1,73 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(stanchion_wm_stats).
+
+-export([init/1,
+         service_available/2,
+         allowed_methods/2,
+         is_authorized/2,
+         content_types_provided/2,
+         produce_body/2]).
+
+-include("stanchion.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+init(Config) ->
+    %% Check if authentication is disabled and
+    %% set that in the context.
+    AuthBypass = proplists:get_value(auth_bypass, Config),
+    {ok, #context{auth_bypass=AuthBypass}}.
+
+-spec service_available(term(), term()) -> {true, term(), term()}.
+service_available(RD, Ctx) ->
+    stanchion_wm_utils:service_available(RD, Ctx).
+
+-spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
+allowed_methods(RD, Ctx) ->
+    {['GET'], RD, Ctx}.
+
+%% @doc Check that the request is from the admin user
+is_authorized(RD, Ctx) ->
+    #context{auth_bypass=AuthBypass} = Ctx,
+    AuthHeader = wrq:get_req_header("authorization", RD),
+    case stanchion_wm_utils:parse_auth_header(AuthHeader, AuthBypass) of
+        {ok, AuthMod, Args} ->
+            case AuthMod:authenticate(RD, Args) of
+                ok ->
+                    %% Authentication succeeded
+                    {true, RD, Ctx};
+                {error, _Reason} ->
+                    %% Authentication failed, deny access
+                    stanchion_response:api_error(access_denied, RD, Ctx)
+            end
+    end.
+
+-spec content_types_provided(term(), term()) ->
+                                    {[{string(), atom()}], term(), term()}.
+content_types_provided(RD, Ctx) ->
+    {[{"application/json", produce_body}], RD, Ctx}.
+
+-spec produce_body(term(), term()) ->
+                          {{'halt', term()}, #wm_reqdata{}, term()}.
+produce_body(RD, Ctx) ->
+    Stats = stanchion_stats:get_stats(),
+    JSON = mochijson2:encode({struct, Stats}),
+    {JSON, RD, Ctx}.

--- a/src/stanchion_wm_stats.erl
+++ b/src/stanchion_wm_stats.erl
@@ -63,7 +63,9 @@ is_authorized(RD, Ctx) ->
 -spec content_types_provided(term(), term()) ->
                                     {[{string(), atom()}], term(), term()}.
 content_types_provided(RD, Ctx) ->
-    {[{"application/json", produce_body}], RD, Ctx}.
+    {[{"application/json", produce_body},
+      {"text/plain", produce_body}],
+     RD, Ctx}.
 
 -spec produce_body(term(), term()) ->
                           {{'halt', term()}, #wm_reqdata{}, term()}.


### PR DESCRIPTION
- Add exometer_core as dependency
- Add message queue length as metric
- Measure metrics on each request to stanchion_server on
  both waiting time and service time
- Add `stanchion-admin` command which serves `status` subcommand
- Add /stats endpoint

This will be the first step to achieve #92. Achievements not yet unlocked are:
- Edit items to count errors (depends on how we merge https://github.com/basho/riak_cs/pull/1180 )
- Add `riakc_pb_socket` metrics (need copying code from CS)
- Add `riak_test`
