### PR TITLE
Remove admin.secret from configuration

### DIFF
--- a/rel/files/stanchion.schema
+++ b/rel/files/stanchion.schema
@@ -29,15 +29,17 @@
 ]}.
 
 %% @doc Admin user credentials. The credentials specified here must
-%% match the admin credentials specified in the riak-cs app.config
-%% for the system to function properly.
+%% match the admin credentials specified in the riak-cs.conf for the
+%% system to function properly.
 {mapping, "admin.key", "stanchion.admin_key", [
   {default, "{{admin_key}}"},
   {datatype, string}
 ]}.
+
+%% @doc admin.secret is deprecated and will be removed at next version.
 {mapping, "admin.secret", "stanchion.admin_secret", [
-  {default, "{{admin_secret}}"},
-  {datatype, string}
+  {datatype, string},
+  hidden
 ]}.
 
 %% @doc {auth_bypass, {{auth_bypass}} } ,

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -17,7 +17,6 @@
 {riak_pb_port,      8087}.
 {auth_bypass,       false}.
 {admin_key,         "admin-key"}.
-{admin_secret,      "admin-secret"}.
 
 %%
 %% etc/vm.args

--- a/src/stanchion_app.erl
+++ b/src/stanchion_app.erl
@@ -77,7 +77,7 @@ check_admin_creds(Pid) ->
                 _ ->
                     ok
             end,
-            StrongOpts = [{r, all}, {pr, one}, {notfound_ok, false}],
+            StrongOpts = [{r, quorum}, {pr, one}, {notfound_ok, false}],
             case riakc_pb_socket:get(Pid, ?USER_BUCKET, KeyId,  StrongOpts) of
                 {ok, Obj} ->
                     case stanchion_utils:from_riakc_obj(Obj, false) of

--- a/src/stanchion_app.erl
+++ b/src/stanchion_app.erl
@@ -24,6 +24,8 @@
 
 -behaviour(application).
 
+-include("stanchion.hrl").
+
 %% application API
 -export([start/2,
          stop/1]).
@@ -41,8 +43,17 @@
                                            {error, term()}.
 start(_Type, _StartArgs) ->
     case stanchion_utils:riak_connection() of
-        {ok, _} ->
-            stanchion_sup:start_link();
+        {ok, Pid} ->
+            try
+                case check_admin_creds(Pid) of
+                    ok ->
+                        stanchion_sup:start_link();
+                    Error ->
+                        Error
+                end
+            after
+                stanchion_utils:close_riak_connection(Pid)
+            end;
         {error, Reason} ->
             _ = lager:error("Couldn't connect to Riak: ~p", [Reason]),
             {error, Reason}
@@ -52,3 +63,39 @@ start(_Type, _StartArgs) ->
 -spec stop(term()) -> ok.
 stop(_State) ->
     ok.
+
+check_admin_creds(Pid) ->
+    case application:get_env(stanchion, admin_key) of
+        {ok, "admin-key"} ->
+            lager:warning("admin.key is defined as default. Please create"
+                          " admin user and configure it.", []),
+            application:set_env(stanchion, admin_secret, "admin-secret");
+        {ok, KeyId} ->
+            case application:get_env(stanchion, admin_secret) of
+                {ok, _} ->
+                    lager:warning("admin.secret is ignored.");
+                _ ->
+                    ok
+            end,
+            StrongOpts = [{r, all}, {pr, one}, {notfound_ok, false}],
+            case riakc_pb_socket:get(Pid, ?USER_BUCKET, KeyId,  StrongOpts) of
+                {ok, Obj} ->
+                    case stanchion_utils:from_riakc_obj(Obj, false) of
+                        {ok, {User, _}} ->
+                            Secret = User?RCS_USER.key_secret,
+                            application:set_env(stanchion, admin_secret, Secret);
+                        Error ->
+                            Error
+                    end;
+                {error, not_found} ->
+                    lager:fatal("admin.key defined in stanchion.conf was not found."
+                                "Please create it."),
+                    {error, admin_not_configured};
+                Error ->
+                    lager:error("Error loading administrator configuration: ~p",
+                                [Error]),
+                    Error
+            end;
+        Error ->
+            Error
+    end.

--- a/test/stanchion_config_test.erl
+++ b/test/stanchion_config_test.erl
@@ -9,7 +9,7 @@ default_config_test() ->
     cuttlefish_unit:assert_config(Config, "stanchion.riak_host", {"127.0.0.1", 8087}),
     cuttlefish_unit:assert_not_configured(Config, "stanchion.ssl"),
     cuttlefish_unit:assert_config(Config, "stanchion.admin_key", "admin-key"),
-    cuttlefish_unit:assert_config(Config, "stanchion.admin_secret", "admin-secret"),
+    cuttlefish_unit:assert_not_configured(Config, "stanchion.admin_secret"),
     cuttlefish_unit:assert_config(Config, "stanchion.auth_bypass", false),
 
     {ok, [ConsoleLog, ErrorLog]} = cuttlefish_unit:path(cuttlefish_variable:tokenize("lager.handlers"), Config),


### PR DESCRIPTION
Instead it is retrieved from Riak directly in startup sequence, from
admin.key specified at configuration file. But in special case
admin.key is specified as "admin-key", it does not retrieve admin
secret from Riak, instead sets it as admin-secret. admin.secret will
be deprecated in near future, which is currently ignored at all.
