### PR TITLE
Bump node_package to 3.0.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.2.0"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.1.1"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish", {tag, "2.0.4"}}},
-        {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "2.0.5"}}},
+        {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "3.0.0"}}},
         {webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.1"}}},
         {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {tag, "1.2"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.2.0"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.1.1"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish", {tag, "2.0.4"}}},
-        {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "2.0.3"}}},
+        {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "2.0.5"}}},
         {webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.1"}}},
         {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {tag, "1.2"}}},


### PR DESCRIPTION
Incorporates the bump to node_package to a new tag, 3.0.0. See also basho/riak_cs#1306. JIRA RCS-357 basho/node_package#196 basho/node_package#200
